### PR TITLE
fix usage is not defined

### DIFF
--- a/resources/views/livewire/usage-hours.blade.php
+++ b/resources/views/livewire/usage-hours.blade.php
@@ -135,12 +135,6 @@
           return
         }
 
-        if (usage === undefined && chart) {
-          chart.destroy()
-          chart = undefined
-          return
-        }
-
         chart.data.labels = labels
         chart.data.datasets[0].data = data
         chart.options.scales.y.max = this.highest(data)


### PR DESCRIPTION
this fixes "Uncaught ReferenceError: usage is not defined" by removing this check since usage is never defined in the code ans so always results in this error