### PR TITLE
Compatibility with Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/contracts": "^10.21",
+        "illuminate/contracts": "^10.21|^11.4",
         "laravel/pulse": "^1.0@beta",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.8",
+        "nunomaduro/collision": "^7.8|^8.1",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.14",
+        "orchestra/testbench": "^8.14|^9.0",
         "pestphp/pest": "^2.20",
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",


### PR DESCRIPTION
This is still failing with the following error, however:

`Problem 1
    - Root composer.json requires abbasudo/pulse-users dev-patch-1 -> satisfiable by abbasudo/pulse-users[dev-patch-1].
    - abbasudo/pulse-users dev-patch-1 requires illuminate/contracts ^10.21|^11.4 -> satisfiable by illuminate/contracts[v10.21.0, ..., 10.x-dev, v11.4.0, 11.x-dev].
    - Only one of these can be installed: illuminate/contracts[dev-master, v5.0.0, ..., 5.8.x-dev, v6.0.0, ..., 6.x-dev, v7.0.0, ..., 7.x-dev, v8.0.0, ..., 8.x-dev, v9.0.0-beta.1, ..., 9.x-dev, v10.0.0, ..., 10.x-dev, v11.0.0, ..., 11.x-dev], laravel/framework[v11.3.1]. laravel/framework replaces illuminate/contracts and thus cannot coexist with it.
    - Root composer.json requires laravel/framework 11.3.1 -> satisfiable by laravel/framework[v11.3.1].`

I guess for L11 compatibility we have a couple of choices:
1. Replace `illuminate/contracts` with `laravel/framework` version `^10.0|^11.0`
2. Have a separate branch with `illuminate/contracts` removed from package.json

Which one is better?